### PR TITLE
fixed a bug in funcs.sh

### DIFF
--- a/conf/funcs.sh
+++ b/conf/funcs.sh
@@ -64,7 +64,7 @@ function check_dir() {
 
 function dir_size() {
     for item in $($HADOOP_EXECUTABLE fs -dus $1); do
-        if [[ $item =~ [0-9]+ ]]; then
+        if [[ $item =~ ^[0-9]+$ ]]; then
             echo $item
         fi
     done


### PR DESCRIPTION
funcs.sh: the function dir_size will return wrong value in hadoop 1.0.3, and I have fixed it.
