### PR TITLE
Fix the error about pagerank when $COMPRESS -eq 0

### DIFF
--- a/pagerank/bin/prepare.sh
+++ b/pagerank/bin/prepare.sh
@@ -28,7 +28,7 @@ DIR=`cd $bin/../; pwd`
 if [ $COMPRESS -eq 1 ]; then
     COMPRESS_OPT="-c ${COMPRESS_CODEC}"
 else
-    COMPRESS_OPT="-c false"
+    COMPRESS_OPT=""
 fi
 
 # generate data


### PR DESCRIPTION
When $COMPRESS -eq 0, COMPRESS_OPT is an unbound variable. And '$HADOOP_EXECUTABLE jar ${DATATOOLS} HiBench.DataGen ${OPTION} ${COMPRESS_OPT}' can not run.
![pagerank](https://cloud.githubusercontent.com/assets/1490540/4041117/6d6b20bc-2cf1-11e4-8739-0341b64afced.png)
