### PR TITLE
fix wrong src_id and dst_id in PagerankNaive.java

### DIFF
--- a/pagerank/src/pegasus/pagerank/PagerankNaive.java
+++ b/pagerank/src/pegasus/pagerank/PagerankNaive.java
@@ -78,7 +78,7 @@ public class PagerankNaive extends Configured implements Tool
 				output.collect( new IntWritable( src_id ), new Text(line[2]) );
 
 				if( make_symmetric == 1 )
-					output.collect( new IntWritable( dst_id ), new Text(line[0]) );
+					output.collect( new IntWritable( dst_id ), new Text(line[1]) );
 			}
 		}
 	}


### PR DESCRIPTION
DummyToPageRankLinksMapper created the edge file which has three elements in every line.
You can see PagerankData.java: line 25, output.collect(key, new Text(from + delim + to)); 
The src_id and dst_id should be the second and third element in the value text line according to DummyToPageRankLinksMapper of PagerankData.java
