### PR TITLE
fix wrong src_id and dst_id

### DIFF
--- a/common/autogen/src/HiBench/PagerankData.java
+++ b/common/autogen/src/HiBench/PagerankData.java
@@ -247,7 +247,7 @@ public class PagerankData {
 				long[] linkids = html.genPureLinkIds();
 				for (int j=0; j<linkids.length; j++) {
 					to = Long.toString(linkids[j]);
-					Text v = new Text(from + delim + to);
+					Text v = new Text(to);
 					output.collect(key, v);
 					reporter.incrCounter(HiBench.Counters.BYTES_DATA_GENERATED, 8+v.getLength());
 				}


### PR DESCRIPTION
This patch is similar with Pull Request #64 .
Make every line of edge file contains only two elements which are src_id and dst_id. Before this modification, there are three which are src_id, src_id and dst_id.
Pagerank can run multiple iterations now with this modification. Have tested it.
