### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 language: java
 jdk:
   - openjdk7


### PR DESCRIPTION
Seems openjdk7 is no longer supported by default VM with Ubuntu Xenial 16.04, see https://docs.travis-ci.com/user/reference/overview .