### PR TITLE
Null output format.

### DIFF
--- a/conf/hibench.conf
+++ b/conf/hibench.conf
@@ -20,7 +20,7 @@ hibench.report.dir		${hibench.home}/report
 # default report file name
 hibench.report.name		hibench.report
 
-# input/output format settings. Available formats: Text, Sequence.
+# input/output format settings. Available formats: Text, Sequence, Null.
 sparkbench.inputformat         Sequence
 sparkbench.outputformat        Sequence
 

--- a/sparkbench/common/src/main/scala/com/intel/hibench/sparkbench/common/IOCommon.scala
+++ b/sparkbench/common/src/main/scala/com/intel/hibench/sparkbench/common/IOCommon.scala
@@ -22,6 +22,7 @@ import java.util.Properties
 
 import org.apache.hadoop.io.compress.CompressionCodec
 import org.apache.hadoop.io.{NullWritable, Text}
+import org.apache.hadoop.mapred.lib.NullOutputFormat
 import org.apache.hadoop.mapred.SequenceFileOutputFormat
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{SparkContext, SparkException}
@@ -65,6 +66,10 @@ class IOCommon(val sc:SparkContext) {
            sequence_data.saveAsHadoopFile[SequenceFileOutputFormat[NullWritable, Text]](filename,
              output_format_codec.get)
          }
+
+       case "Null" =>
+         data.map(x => (NullWritable.get(), new Text(x.toString)))
+           .saveAsHadoopFile[NullOutputFormat[NullWritable, Text]](filename)
 
        case _ => throw new UnsupportedOperationException(s"Unknown output format: $output_format")
      }


### PR DESCRIPTION
Null output format is handy for benchmarking shuffle, to reduce disk IO component. Also, it allows to not reserve space on hdfs for output.