### PR TITLE
Add master "yarn" support for parsing submit parameters

### DIFF
--- a/bin/functions/workload_functions.sh
+++ b/bin/functions/workload_functions.sh
@@ -199,7 +199,7 @@ function run_spark_job() {
     export_withlog SPARKBENCH_PROPERTIES_FILES
 
     YARN_OPTS=""
-    if [[ "$SPARK_MASTER" == yarn-* ]]; then
+    if [[ "$SPARK_MASTER" == yarn-* ]] || [[ "$SPARK_MASTER" == yarn ]]; then
         export_withlog HADOOP_CONF_DIR
         
         YARN_OPTS="--num-executors ${YARN_NUM_EXECUTORS}"


### PR DESCRIPTION
Master yarn-client is deprecated since 2.0 and not supported in 3.0.0. Should use master "yarn" with specified deploy mode instead. This fix add support for master "yarn".

Related setting in spark.conf, use

hibench.spark.master    yarn

instead of 

hibench.spark.master    yarn-client

