### PR TITLE
Add seed setting to KMeans

### DIFF
--- a/sparkbench/ml/src/main/scala/com/intel/sparkbench/ml/DenseKMeans.scala
+++ b/sparkbench/ml/src/main/scala/com/intel/sparkbench/ml/DenseKMeans.scala
@@ -108,6 +108,7 @@ object DenseKMeans {
       .setInitializationMode(initMode)
       .setK(params.k)
       .setMaxIterations(params.numIterations)
+      .setSeed(1L)
       .run(examples)
 
     val cost = model.computeCost(examples)


### PR DESCRIPTION
Default seed for KMeans initialization is random. Initialization points will impact KMeans iterations, convergence and result. For benchmark purpose, a fixed seed will result in consistent initialization and results from run to run. 