### PR TITLE
Make storage level configurable in kmeans

### DIFF
--- a/bin/functions/hibench_prop_env_mapping.py
+++ b/bin/functions/hibench_prop_env_mapping.py
@@ -93,6 +93,7 @@ HiBenchEnvPropMapping=dict(
     DIMENSIONS="hibench.kmeans.dimensions",
     MAX_ITERATION="hibench.kmeans.max_iteration",
     K="hibench.kmeans.k",
+    K_STORAGE_LEVEL="hibench.kmeans.storage.level",
     # For Logistic Regression
     NUM_EXAMPLES_LR="hibench.lr.examples",
     NUM_FEATURES_LR="hibench.lr.features",

--- a/bin/workloads/ml/kmeans/spark/run.sh
+++ b/bin/workloads/ml/kmeans/spark/run.sh
@@ -28,7 +28,7 @@ rmr_hdfs $OUTPUT_HDFS || true
 SIZE=`dir_size $INPUT_HDFS`
 START_TIME=`timestamp`
 
-run_spark_job com.intel.hibench.sparkbench.ml.DenseKMeans -k $K --numIterations $MAX_ITERATION $INPUT_HDFS/samples
+run_spark_job com.intel.hibench.sparkbench.ml.DenseKMeans -k $K --numIterations $MAX_ITERATION --storageLevel $K_STORAGE_LEVEL $INPUT_HDFS/samples
 END_TIME=`timestamp`
 
 gen_report ${START_TIME} ${END_TIME} ${SIZE}


### PR DESCRIPTION
This PR will add storage level conf in kmeans workloads and make it configurable.
Background for this PR
We are testing some other storage level (customized storage level for Optane PMem). We'd better have configurable interface in kmeans workload.