### PR TITLE
Docs update: deprecate Spark 2.3- support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ There are totally 29 workloads in HiBench. The workloads are divided into 6 cate
     
 ### Supported Hadoop/Spark/Flink/Storm/Gearpump releases: ###
 
-  - Hadoop: Apache Hadoop 3.0.x, Apache Hadoop 3.1.x, Apache Hadoop 3.2.x, Apache Hadoop 2.x, CDH5, HDP
+  - Hadoop: Apache Hadoop 3.0.x, 3.1.x, 3.2.x, 2.x, CDH5, HDP
   - Spark: Spark 2.4.x, Spark 3.0.x
   - Flink: 1.0.3
   - Storm: 1.0.1

--- a/docs/run-sparkbench.md
+++ b/docs/run-sparkbench.md
@@ -4,15 +4,15 @@
  
  * `bc` is required to generate the HiBench report.
 
- * Supported Hadoop version: Apache Hadoop 2.x, CDH5.x, HDP
+ * Supported Hadoop version: Apache Hadoop 2.x, 3.0.x, 3.1.x, 3.2.x, CDH5.x, HDP
 
- * Supported Spark version: 1.6.x, 2.0.x, 2.1.x, 2.2.x
+ * Supported Spark version: 2.4.x, 3.0.x
 
  * Build HiBench according to [build HiBench](build-hibench.md).
 
  * Start HDFS, Yarn, Spark in the cluster.
 
-
+Note: Starting from HiBench 8.0, the support of Spark before 2.3.x(inclusive) was deprecated, please either leverage former version HiBench or upgrade your Spark.
 
 ### 2. Configure `hadoop.conf` ###
 


### PR DESCRIPTION
 Clarified deprecating Spark 2.3- support. It's already been removed in Travis, docs not updated.