### PR TITLE
[HIBENCH-648]make storage level configurable in SVM

### DIFF
--- a/bin/functions/hibench_prop_env_mapping.py
+++ b/bin/functions/hibench_prop_env_mapping.py
@@ -112,6 +112,7 @@ HiBenchEnvPropMapping=dict(
     NUM_FEATURES_SVM="hibench.svm.features",
     NUM_ITERATIONS_SVM="hibench.svm.numIterations",
     STEPSIZE_SVM="hibench.svm.stepSize",
+    SVM_STORAGE_LEVEL="hibench.svm.storage.level",
     REGPARAM_SVM="hibench.svm.regParam",
     # For ALS
     NUM_USERS_ALS="hibench.als.users",

--- a/bin/workloads/ml/svm/spark/run.sh
+++ b/bin/workloads/ml/svm/spark/run.sh
@@ -26,7 +26,7 @@ rmr_hdfs $OUTPUT_HDFS || true
 
 SIZE=`dir_size $INPUT_HDFS`
 START_TIME=`timestamp`
-run_spark_job com.intel.hibench.sparkbench.ml.SVMWithSGDExample --numIterations $NUM_ITERATIONS_SVM --stepSize $STEPSIZE_SVM --regParam $REGPARAM_SVM $INPUT_HDFS
+run_spark_job com.intel.hibench.sparkbench.ml.SVMWithSGDExample --numIterations $NUM_ITERATIONS_SVM --storageLevel $SVM_STORAGE_LEVEL --stepSize $STEPSIZE_SVM --regParam $REGPARAM_SVM $INPUT_HDFS
 END_TIME=`timestamp`
 
 gen_report ${START_TIME} ${END_TIME} ${SIZE}

--- a/conf/workloads/ml/svm.conf
+++ b/conf/workloads/ml/svm.conf
@@ -22,3 +22,5 @@ hibench.svm.regParam                     0.01
 
 hibench.workload.input                   ${hibench.hdfs.data.dir}/SVM/Input
 hibench.workload.output                  ${hibench.hdfs.data.dir}/SVM/Output
+
+hibench.svm.storage.level                MEMORY_ONLY


### PR DESCRIPTION
For [HiBench-648],add  storage level configurable to SVM.
This facilitates the use of SVM to test the function of OAP RDD Cache without recompiling the project.