### PR TITLE
Update Scopt version to avoid Scala version conflict with Spark-3.1.2 

### DIFF
--- a/autogen/pom.xml
+++ b/autogen/pom.xml
@@ -58,7 +58,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.scopt</groupId>
-      <artifactId>scopt_2.12</artifactId>
+      <artifactId>scopt_${scala.binary.version}</artifactId>
       <version>${scopt.version}</version>
     </dependency>
     <dependency>

--- a/autogen/pom.xml
+++ b/autogen/pom.xml
@@ -58,7 +58,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.scopt</groupId>
-      <artifactId>scopt_2.10</artifactId>
+      <artifactId>scopt_2.12</artifactId>
       <version>${scopt.version}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <scala.binary.version>2.10</scala.binary.version>
     <slf4j.version>1.7.5</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
-    <scopt.version>3.2.0</scopt.version>
+    <scopt.version>3.7.0</scopt.version>
     <mahout.version>0.9</mahout.version>
     <uncommons-maths.version>1.2.2a</uncommons-maths.version>
     <junit.version>3.8.1</junit.version>

--- a/sparkbench/dal/pom.xml
+++ b/sparkbench/dal/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.scopt</groupId>
-      <artifactId>scopt_2.12</artifactId>
+      <artifactId>scopt_${scala.binary.version}</artifactId>
       <version>${scopt.version}</version>
     </dependency>
     <dependency>

--- a/sparkbench/dal/pom.xml
+++ b/sparkbench/dal/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.scopt</groupId>
-      <artifactId>scopt_2.10</artifactId>
+      <artifactId>scopt_2.12</artifactId>
       <version>${scopt.version}</version>
     </dependency>
     <dependency>

--- a/sparkbench/ml/pom.xml
+++ b/sparkbench/ml/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.scopt</groupId>
-      <artifactId>scopt_2.12</artifactId>
+      <artifactId>scopt_${scala.binary.version}</artifactId>
       <version>${scopt.version}</version>
     </dependency>
     <dependency>

--- a/sparkbench/ml/pom.xml
+++ b/sparkbench/ml/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.scopt</groupId>
-      <artifactId>scopt_2.10</artifactId>
+      <artifactId>scopt_2.12</artifactId>
       <version>${scopt.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Spark 3.1.2 use Scala 2.12.x, but HiBench's dependency -- Scopt specifies Scala to 2.10 which will lead to version conflict when running Hibench with Dataproc 2.0 vanilla Spark.
So here update Scopt version and its artifactId.

This PR is tested on Dataproc 2.0 successfully.

![image](https://user-images.githubusercontent.com/30172512/133881584-97206063-6a1d-4faf-a0e7-6a5e872a926d.png)

Also passed bigdata profile workflow on n2-standard-80 (1 master +3 workers ) cluster 

![image](https://user-images.githubusercontent.com/30172512/133883620-292d8a38-23cd-43fe-9664-8df22953bb2d.png)
