### PR TITLE
Fix syntax error in CorrelationExample

### DIFF
--- a/sparkbench/ml/src/main/scala/com/intel/sparkbench/ml/CorrelationExample.scala
+++ b/sparkbench/ml/src/main/scala/com/intel/sparkbench/ml/CorrelationExample.scala
@@ -11,7 +11,7 @@ object CorrelationExample {
 
   case class Params(
        input: String = null,
-       corrType: String = "pearson",
+       corrType: String = "pearson"
        )
 
   def main(args: Array[String]): Unit = {


### PR DESCRIPTION
I encountered this while building sparkbench. I think my change is correct, but I'm not sure. Please tell me if it's not.