### PR TITLE
Correct environment variable for Spark driver memory under YARN

### DIFF
--- a/bin/functions/workload_functions.sh
+++ b/bin/functions/workload_functions.sh
@@ -209,7 +209,7 @@ function run_spark_job() {
        if [[ -n "${SPARK_YARN_EXECUTOR_MEMORY:-}" ]]; then
            YARN_OPTS="${YARN_OPTS} --executor-memory ${SPARK_YARN_EXECUTOR_MEMORY}"
        fi
-       if [[ -n "${SPAKR_YARN_DRIVER_MEMORY:-}" ]]; then
+       if [[ -n "${SPARK_YARN_DRIVER_MEMORY:-}" ]]; then
            YARN_OPTS="${YARN_OPTS} --driver-memory ${SPARK_YARN_DRIVER_MEMORY}"
        fi
     fi


### PR DESCRIPTION
Corrects a a typo in the name for the environment variable SPARK_YARN_DRIVER_MEMORY that currently prevents passing the --driver-memory option correctly to Spark when using YARN