### PR TITLE
fix(sec): upgrade org.apache.flink:flink-core to 1.10.1

### DIFF
--- a/flinkbench/pom.xml
+++ b/flinkbench/pom.xml
@@ -16,7 +16,7 @@
   <name>flinkbench</name>
 
   <properties>
-    <flinkVersion>1.0.3</flinkVersion>
+    <flinkVersion>1.10.1</flinkVersion>
     <jackson.version>2.4.2</jackson.version>
   </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.flink:flink-core 1.0.3
- [CVE-2020-1960](https://issues.apache.org/jira/browse/FLINK-16697)


### What did I do？
Upgrade org.apache.flink:flink-core from 1.0.3 to 1.10.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
No.