### PR TITLE
fix could not parse as YAML

### DIFF
--- a/.github/workflows/hibench_ci_spark3.1_hadoop_3.2_part_2.yml
+++ b/.github/workflows/hibench_ci_spark3.1_hadoop_3.2_part_2.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    for publishing the docs to GH Pages
+
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Set up JDK 1.8


### PR DESCRIPTION
The YAML file has a style issue that prevents the CI from parsing it, resulting in a score of -1 for OpenSSF Pinned-Dependencies and Token-Permissions.

**Problem Description:**
![image](https://github.com/Intel-bigdata/HiBench/assets/45281494/8575a910-c6c4-474a-a8fb-f6af1c0bc582)

![image](https://github.com/Intel-bigdata/HiBench/assets/45281494/7409945b-2150-4141-a8df-2c356408c916)

![image](https://github.com/Intel-bigdata/HiBench/assets/45281494/6eaf5dfd-2709-43ac-8c76-45f427b3dae6)
